### PR TITLE
Add back Ruby 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 os:
   - xenial # we cannot actually test until xenial is added to Travis
 rvm:
+  - '2.0.0'
   - '2.1.0'
   - '2.2.4'
   - '2.3.0'

--- a/journald-logger.gemspec
+++ b/journald-logger.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'journald-native', '~> 1.0'
 

--- a/lib/journald/modules/exceptionable.rb
+++ b/lib/journald/modules/exceptionable.rb
@@ -9,8 +9,11 @@ module Journald
       private
 
         def real_exception(e, priority, is_cause)
-          # get backtrace if present
-          bt = e.backtrace_locations &&
+          # for Ruby 2.1 get cause if present
+          cause = if e.respond_to? :cause; e.cause; end
+          # for Ruby 2.1 get backtrace if present
+          bt = e.respond_to?(:backtrace_locations) &&
+               e.backtrace_locations &&
                e.backtrace_locations.length > 0
 
           tag_trace_location(e.backtrace_locations[0]) if bt
@@ -22,12 +25,12 @@ module Journald
               exception_class:          e.class.name,
               exception_message:        e.message,
               backtrace:                bt ? e.backtrace.join("\n"): nil,
-              cause:                    e.cause ? e.cause.inspect : nil,
+              cause:                    cause ? cause.inspect : nil,
           )
 
           untag_trace_location if bt
 
-          real_exception(e.cause, priority, true) if e.cause
+          real_exception(cause, priority, true) if cause
         end
     end
   end


### PR DESCRIPTION
I know this might sound weird, but let me explain. Ruby 2.0 is EOL upstream, but this version is in Red Hat Enterprise Linux 7 and therefore it will be supported by Red Hat for 13+ years from the release (that is seven more if I count correct). Our project (1) and product runs on Ruby 2.0 so far and although we are discussing migration to Software Collections and latest Ruby, it's bunch of packaging work and we are not yet there for the component (2) I am working on at the moment. We will eventually upgrade our stack, that is for sure.

Initial idea was to add a dependency on verison 1.1.1 but there is at least one patch I would need (silence method), therefore I'd probably need to fork your project myself. That is not what I want to do. Therefore this PR is an attempt to see how much work is adding Ruby 2.0 support back, I want to trigger Travis CI run to see more.

Since I don't see any new features from Ruby 2.1 used in the codebase, I wonder if there are other reasons like in the native dependnecy. That would make things more complex for this attempt.

What is your opinion on bringing Ruby 2.0 back into the game? Thanks

Edit: Looks like I am not in CI whitelist, tests do not start. Anyway, I'd like to ask you for a favour - if you are fine with this and tests pass and you merge this, can you release minor release for me? :-)

* (1) https://theforeman.org
* (2) https://github.com/theforeman/smart-proxy/pull/611#discussion_r223319164